### PR TITLE
adding extern to FILE variables

### DIFF
--- a/hello_uart/uart.c
+++ b/hello_uart/uart.c
@@ -8,6 +8,9 @@
 
 /* http://www.cs.mun.ca/~rod/Winter2007/4723/notes/serial/serial.html */
 
+FILE uart_output = FDEV_SETUP_STREAM(uart_putchar, NULL, _FDEV_SETUP_WRITE);
+FILE uart_input = FDEV_SETUP_STREAM(NULL, uart_getchar, _FDEV_SETUP_READ);
+
 void uart_init(void) {
     UBRR0H = UBRRH_VALUE;
     UBRR0L = UBRRL_VALUE;

--- a/hello_uart/uart.h
+++ b/hello_uart/uart.h
@@ -5,5 +5,5 @@ void uart_init(void);
 
 /* http://www.ermicro.com/blog/?p=325 */
 
-FILE uart_output = FDEV_SETUP_STREAM(uart_putchar, NULL, _FDEV_SETUP_WRITE);
-FILE uart_input = FDEV_SETUP_STREAM(NULL, uart_getchar, _FDEV_SETUP_READ);
+extern FILE uart_output;
+extern FILE uart_input;

--- a/hello_uart_async/uart.h
+++ b/hello_uart_async/uart.h
@@ -8,5 +8,5 @@ struct tx_ring;
 
 /* http://www.ermicro.com/blog/?p=325 */
 
-FILE uart_output = FDEV_SETUP_STREAM(uart_putchar, NULL, _FDEV_SETUP_WRITE);
-FILE uart_input = FDEV_SETUP_STREAM(NULL, uart_getchar, _FDEV_SETUP_READ);
+extern FILE uart_output;
+extern FILE uart_input;

--- a/hello_uart_async/uart_async.c
+++ b/hello_uart_async/uart_async.c
@@ -32,6 +32,10 @@ struct rx_ring {
 static struct tx_ring tx_buffer;
 static struct rx_ring rx_buffer;
 
+FILE uart_output = FDEV_SETUP_STREAM(uart_putchar, NULL, _FDEV_SETUP_WRITE);
+FILE uart_input = FDEV_SETUP_STREAM(NULL, uart_getchar, _FDEV_SETUP_READ);
+
+
 /* http://www.cs.mun.ca/~rod/Winter2007/4723/notes/serial/serial.html */
 
 void uart_init(void) {


### PR DESCRIPTION
this is the proper way to extern the FILE objects.  Without this, the linker will crash and burn if two .c files import uart.h
